### PR TITLE
-Add Attribute fields and Values options for Params

### DIFF
--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/pi/util/impl/ExtendedParameterImpl.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/pi/util/impl/ExtendedParameterImpl.xtend
@@ -47,44 +47,48 @@ class ExtendedParameterImpl extends ParameterImpl implements ExtendedParameter {
 	
 	def String parsingType(StandardTypes types) {
 		
-		    var String value = "";
+		    
 		switch (types.type.getName()){
 			case "Integer" :{
-				value = "Integer"
+				return "Integer"
 			}
 			case "Boolean" :{
-			value = "Yes_No_Buttons"
+			return "Yes_No_Buttons"
 				
 			}
 			case "Textarea" :{
-				value = "Textarea"
+				return "Textarea"
 			}
 			case "Textfield" :{
-				value = "Text_Field"
+				return "Text_Field"
 			} 
 			case "Time":{
-				value = "Datepicker"
+				return "Datepicker"
 			}
 			case "Date":{
-				value = "Datepicker"
+				return "Datepicker"
 			}
 			case "Datetime" :{
-				value = "Datepicker"
+				return "Datepicker"
 				}
 			case "Link" :{
-				value = "Text_Field"
+				return "Text_Field"
 			}
 			case "Image":{
-				value = "Imagepicker"
+				return "Imagepicker"
 			}
 			case "File" :{
-				value = "Filepicker"
+				return "Filepicker"
 			}
 			case "Label":{
-				value = "Text_Field_NE"
+				return "Text_Field_NE"
+			}
+			default: {
+				return types.type.getName()
 			}
 			
 		}
+		
 	}
 	
 	override generatorType() {

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaExtensionGenerator/ComponentGenerator.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaExtensionGenerator/ComponentGenerator.xtend
@@ -659,7 +659,7 @@ public class ComponentGenerator extends AbstractExtensionGenerator {
 		    «FOR g : component.extendedParameterGroupList»
 		    <fieldset name="«g.name.toLowerCase»" label="«g.name.toUpperCase»_LABEL" description="«g.name.toUpperCase»_DESC">
 		        «FOR p:g.extendedParameterList»
-		        «Slug.writeParameter(p)»
+		        «Slug.writeParameter(p,component)»
 		        «ENDFOR»
 		    </fieldset>
 		    «ENDFOR»

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaPageGenerator/AbstractPageGenerator.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaPageGenerator/AbstractPageGenerator.xtend
@@ -98,7 +98,7 @@ abstract public class AbstractPageGenerator {
 	
 	def CharSequence generateParameter(EList<ExtendedParameter>listParams, ExtendedComponent component)'''
 	    «FOR param : listParams»
-		    «Slug.writeParameter(param)»
+		    «Slug.writeParameter(param,component)»
 		«ENDFOR»
 	'''
 		

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaPageGenerator/DynamicPageTemplate.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaPageGenerator/DynamicPageTemplate.xtend
@@ -180,7 +180,7 @@ public abstract class DynamicPageTemplate extends AbstractPageGenerator {
 	
 	override CharSequence generateParameter(EList<ExtendedParameter>listParams, ExtendedComponent component)'''
 	«FOR param : listParams»
-	«Slug.writeParameter(param)»
+	«Slug.writeParameter(param,component)»
 	«ENDFOR»
 	'''
 	

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaUtil/Slug.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaUtil/Slug.xtend
@@ -36,6 +36,7 @@ import java.util.GregorianCalendar
 import org.eclipse.emf.common.util.EList
 import de.thm.icampus.joomdd.ejsl.generator.ps.joomla.LinkGeneratorHandler
 import java.util.ArrayList
+import de.thm.icampus.joomdd.ejsl.eJSL.KeyValuePair
 
 /**
  * This class contains templates which are often used in different contexts.
@@ -1004,15 +1005,127 @@ public class Slug  {
 	}
 
     static def CharSequence writeParameter(
-		ExtendedParameter param) '''
-		<field
-		name="«param.name»"
-		«Slug.getTypeName(param)»
-		default="«param.defaultvalue»"
-		label="«param.label»"
-		description="«param.descripton»"
-		>
-	'''
+		ExtendedParameter param, ExtendedComponent component) {
+			    var String type = getTypeName(param)
+				val String[] type_temp_array = type.split('''"'''.toString())
+   		val String type_temp = type_temp_array.get(1)
+   		
+   		switch(type_temp){
+   		    case "multiselect" , case "select", case "list": {
+   	        return '''
+   		    <field name="«param.name.toLowerCase»"
+   		            type="list" 
+   		            «IF type.equalsIgnoreCase("multiselect")»
+   		            multiple
+   		            «ENDIF»
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            «FOR KeyValuePair kv: param.values»
+   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+   		            «ENDFOR»
+   		        </field> 
+   		        '''
+   		    }
+   		    case "imagepicker": {
+   		        return '''
+   		        <field name="«param.name.toLowerCase»"
+   		            type ="imageloader"
+   		            accept="image/*"
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		    case "filepicker": {
+   		        return '''
+   		        <field name="«param.name.toLowerCase»"
+   		            type ="fileloader"
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+  		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		    case "checkbox": {
+   		       return ''' 
+   		        <field name="«param.name.toLowerCase»"
+   		            type="checkboxes" 
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            «FOR KeyValuePair kv: param.values»
+   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+   		            «ENDFOR»
+   		        </field> 
+   		        '''
+   		    }
+   		    case "radiobutton": {
+   		        return ''' 
+	   		        <field name="«param.name.toLowerCase»"
+	   		            type="radio"
+	   		            id="«param.name.toLowerCase»"
+	   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+	   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+	   		            «FOR KeyValuePair kvpair : param.attributes»
+	   		            «kvpair.name» = "«kvpair.value»"
+	   		            «ENDFOR»
+	   		            >
+	   		            «FOR KeyValuePair kv: param.values»
+	   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+	   		            «ENDFOR»
+	   		        </field> 
+   		        '''
+   		    }
+   		    case "Yes_No_Buttons": {
+   		        return ''' 
+   		        <field name="«param.name.toLowerCase»"
+   		            type="radio" 
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            default="0"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            <option value="1">JYES</option>
+   		            <option value="0">JNO</option>
+   		        </field> 
+   		        '''
+   		    }
+   		    default: {
+   		        return '''  
+   		        <field name="«param.name.toLowerCase»"
+   		            «type»
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		}
+   	
+   	}
+		
 	
     static def ExtendedDetailPageField getEditedFieldsForattribute(ExtendedDynamicPage dynPage, ExtendedAttribute attr){
 		for (ExtendedDetailPageField field:dynPage.extendedEditedFieldsList ) {
@@ -1024,19 +1137,19 @@ public class Slug  {
 	}
 	
     //get all other referenced in the referenced Entity	
-	def static EList<Attribute> getOtherAttribute(ExtendedReference reference) {
+	static def  EList<Attribute> getOtherAttribute(ExtendedReference reference) {
 	    var Entity toEntity = reference.destinationEntity
 	    var Reference ref = (toEntity.references.filter[t | !t.entity.name.equalsIgnoreCase( reference.sourceEntity.name)]).get(0)
 	    return ref.attribute
 	}
 	
-	def static Entity getOtherEntityToMapping(ExtendedReference reference) {
+	static def  Entity getOtherEntityToMapping(ExtendedReference reference) {
 	    var Entity toEntity = reference.destinationEntity
 	    var Reference ref = (toEntity.references.filter[t | !t.entity.name.equalsIgnoreCase(reference.sourceEntity.name)]).get(0)
 	    return ref.entity
 	}
 	
-	def static CharSequence generateEntytiesBackendInputRefrence(ExtendedReference reference, ExtendedComponent com) '''
+	 static def  CharSequence generateEntytiesBackendInputRefrence(ExtendedReference reference, ExtendedComponent com) '''
 	    <?php if (Factory::getUser()->authorise('core.admin','«com.name.toLowerCase»')) : ?>
 	    <?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', '«Slug.getOtherEntityToMapping(reference).name.toLowerCase»', Text::_('«Slug.nameExtensionBind("com",com.name).toUpperCase»_«Slug.getOtherEntityToMapping(reference).name.toUpperCase»', true)); ?>
 	    <div class="control-group">

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaExtensionGenerator/ComponentGenerator.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaExtensionGenerator/ComponentGenerator.xtend
@@ -714,7 +714,7 @@ public class ComponentGenerator extends AbstractExtensionGenerator {
 		    «FOR g : component.extendedParameterGroupList»
 		    <fieldset name="«g.name.toLowerCase»" label="«g.name.toUpperCase»_LABEL" description="«g.name.toUpperCase»_DESC">
 		        «FOR p:g.extendedParameterList»
-		        «Slug.writeParameter(p)»
+		        «Slug.writeParameter(p,component)»
 		        «ENDFOR»
 		    </fieldset>
 		    «ENDFOR»

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaPageGenerator/AbstractPageGenerator.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaPageGenerator/AbstractPageGenerator.xtend
@@ -98,7 +98,7 @@ abstract public class AbstractPageGenerator {
 	
 	def CharSequence generateParameter(EList<ExtendedParameter>listParams, ExtendedComponent component)'''
 	    «FOR param : listParams»
-		    «Slug.writeParameter(param)»
+		    «Slug.writeParameter(param,component)»
 		«ENDFOR»
 	'''
 		

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaPageGenerator/DynamicPageTemplate.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaPageGenerator/DynamicPageTemplate.xtend
@@ -180,7 +180,7 @@ public abstract class DynamicPageTemplate extends AbstractPageGenerator {
 	
 	override CharSequence generateParameter(EList<ExtendedParameter>listParams, ExtendedComponent component)'''
 	«FOR param : listParams»
-	«Slug.writeParameter(param)»
+	«Slug.writeParameter(param,component)»
 	«ENDFOR»
 	'''
 	

--- a/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaUtil/Slug.xtend
+++ b/development/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla4/JoomlaUtil/Slug.xtend
@@ -36,6 +36,7 @@ import java.util.GregorianCalendar
 import org.eclipse.emf.common.util.EList
 import de.thm.icampus.joomdd.ejsl.generator.ps.joomla4.LinkGeneratorHandler
 import java.util.ArrayList
+import de.thm.icampus.joomdd.ejsl.eJSL.KeyValuePair
 
 /**
  * This class contains templates which are often used in different contexts.
@@ -1009,16 +1010,127 @@ def static String getTypeName(String type) {
 		return ""
 	}
 
-    static def CharSequence writeParameter(
-		ExtendedParameter param) '''
-		<field
-		name="«param.name»"
-		«Slug.getTypeName(param)»
-		default="«param.defaultvalue»"
-		label="«param.label»"
-		description="«param.descripton»"
-		>
-	'''
+      static def CharSequence writeParameter(
+		ExtendedParameter param, ExtendedComponent component) {
+			    var String type = getTypeName(param)
+				val String[] type_temp_array = type.split('''"'''.toString())
+   		val String type_temp = type_temp_array.get(1)
+   		
+   		switch(type_temp){
+   		    case "multiselect" , case "select", case "list": {
+   	        return '''
+   		    <field name="«param.name.toLowerCase»"
+   		            type="list" 
+   		            «IF type.equalsIgnoreCase("multiselect")»
+   		            multiple
+   		            «ENDIF»
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            «FOR KeyValuePair kv: param.values»
+   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+   		            «ENDFOR»
+   		        </field> 
+   		        '''
+   		    }
+   		    case "imagepicker": {
+   		        return '''
+   		        <field name="«param.name.toLowerCase»"
+   		            type ="imageloader"
+   		            accept="image/*"
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		    case "filepicker": {
+   		        return '''
+   		        <field name="«param.name.toLowerCase»"
+   		            type ="fileloader"
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+  		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		    case "checkbox": {
+   		       return ''' 
+   		        <field name="«param.name.toLowerCase»"
+   		            type="checkboxes" 
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            «FOR KeyValuePair kv: param.values»
+   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+   		            «ENDFOR»
+   		        </field> 
+   		        '''
+   		    }
+   		    case "radiobutton": {
+   		        return ''' 
+	   		        <field name="«param.name.toLowerCase»"
+	   		            type="radio"
+	   		            id="«param.name.toLowerCase»"
+	   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+	   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+	   		            «FOR KeyValuePair kvpair : param.attributes»
+	   		            «kvpair.name» = "«kvpair.value»"
+	   		            «ENDFOR»
+	   		            >
+	   		            «FOR KeyValuePair kv: param.values»
+	   		            <option value="«kv.value»">«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_«kv.name.toUpperCase»_OPTION</option>
+	   		            «ENDFOR»
+	   		        </field> 
+   		        '''
+   		    }
+   		    case "Yes_No_Buttons": {
+   		        return ''' 
+   		        <field name="«param.name.toLowerCase»"
+   		            type="radio" 
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            default="0"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            >
+   		            <option value="1">JYES</option>
+   		            <option value="0">JNO</option>
+   		        </field> 
+   		        '''
+   		    }
+   		    default: {
+   		        return '''  
+   		        <field name="«param.name.toLowerCase»"
+   		            «type»
+   		            id="«param.name.toLowerCase»"
+   		            label="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»"
+   		            description="«Slug.nameExtensionBind("com",component.name).toUpperCase»_PARAM_«param.name.toUpperCase»_DESC"
+   		            «FOR KeyValuePair kvpair : param.attributes»
+   		            «kvpair.name» = "«kvpair.value»"
+   		            «ENDFOR»
+   		            />
+   		        '''
+   		    }
+   		}
+   	
+   	}
 	
     static def ExtendedDetailPageField getEditedFieldsForattribute(ExtendedDynamicPage dynPage, ExtendedAttribute attr){
 		for (ExtendedDetailPageField field:dynPage.extendedEditedFieldsList ) {


### PR DESCRIPTION
#60 
The issue should be fixed now.
Options are only generated if a suitable type is selected in the model. Such types are Select, Multiselect,... but not Text_field.