### PR TITLE
Fixed some language generation problems

### DIFF
--- a/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaUtil/KVPairLanguage.xtend
+++ b/de.thm.icampus.joomdd.ejsl.parent/de.thm.icampus.joomdd.ejsl/src/de/thm/icampus/joomdd/ejsl/generator/ps/joomla/JoomlaUtil/KVPairLanguage.xtend
@@ -24,4 +24,10 @@ public class KVPairLanguage extends KVPairInterface {
 		return '''«kv.name.toUpperCase»="«kv.value»"'''
 	}
 	
+	override equals(Object o) {
+		if (o instanceof KVPairLanguage) {
+			return this.kv.name.equals(o.kv.name)
+		}
+		return false
+	}	
 }


### PR DESCRIPTION
Fixed: The manifest file did not contain the language links that we added later.
Fixed: Frontend language constants were not available in the backend
(for menu item). This works but need improvement (see #144).